### PR TITLE
docs(README): link to the contribution guidelines (#7)

### DIFF
--- a/.github/workflows/move_articles.yml
+++ b/.github/workflows/move_articles.yml
@@ -14,7 +14,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Move one article from _drafts to new_posts
       run: |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # abcdR
+
+Sources of the [abcdR](https://abcdr.thinkr.fr) blog — a French-language R
+magazine published by [ThinkR](https://thinkr.fr).
+
+## Contributing an article
+
+Guidelines and the full submission workflow live on the blog itself:
+
+→ <https://abcdr.thinkr.fr/soumettre-un-article/>
+
+In short: fork this repository, add your article under `new_posts/` using
+`generate_article.R` as a scaffold, and open a pull request.


### PR DESCRIPTION
## Summary
- README rewritten with a one-paragraph intro and a pointer to the `soumettre-un-article` page on the live blog.
- Short reminder of the fork → `new_posts/` → PR loop, matching the workflow described on the blog.

## Test plan
- [x] Visual diff on the rendered README.
- [x] Link resolves to https://abcdr.thinkr.fr/soumettre-un-article/.

Closes #7